### PR TITLE
Convert all headers to lower case before setting them

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,17 +147,24 @@ export function twoStroke<T extends Env>(title: string, release: string) {
                 });
               }
             }
-            response.headers = response.headers ?? {};
-            response.headers["Content-Type"] =
-              response.headers["Content-Type"] ?? "application/json";
-            response.headers["Access-Control-Allow-Origin"] =
-              response.headers["Access-Control-Allow-Origin"] ?? "*";
+            // convert all headers keys to lowercase
+            response.headers = Object.fromEntries(
+              Object.entries(response.headers ?? {}).map(([key, value]) => [
+                key.toLowerCase(),
+                value,
+              ])
+            );
+
+            response.headers["content-type"] =
+              response.headers["content-type"] ?? "application/json";
+            response.headers["access-control-allow-origin"] =
+              response.headers["access-control-allow-origin"] ?? "*";
             return new Response(
               // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              response.headers["Content-Type"] === "application/json"
+              response.headers["content-type"] === "application/json"
                 ? JSON.stringify(response.body)
                 : response.body,
-              response,
+              response
             );
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,24 +147,17 @@ export function twoStroke<T extends Env>(title: string, release: string) {
                 });
               }
             }
-            // convert all headers keys to lowercase
-            response.headers = Object.fromEntries(
-              Object.entries(response.headers ?? {}).map(([key, value]) => [
-                key.toLowerCase(),
-                value,
-              ])
-            );
-
-            response.headers["content-type"] =
-              response.headers["content-type"] ?? "application/json";
-            response.headers["access-control-allow-origin"] =
-              response.headers["access-control-allow-origin"] ?? "*";
+            const headers = new Headers(response.headers ?? {});
+            if (!headers.has("Content-Type"))
+              headers.set("Content-Type", "application/json");
+            if (!headers.has("Access-Control-Allow-Origin"))
+              headers.set("Access-Control-Allow-Origin", "*");
             return new Response(
               // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              response.headers["content-type"] === "application/json"
+              headers.get("Content-Type") === "application/json"
                 ? JSON.stringify(response.body)
                 : response.body,
-              response
+              response,
             );
           }
         }


### PR DESCRIPTION
When changing over huddle engine I noticed that the headers were not being set correctly. I think fetch was lower casing headers automatically, however we were assuming that the headers were case sensitive. This commit converts all headers to lower case before setting/overwriting them.