### PR TITLE
Optionally make the POST input schema dynamic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,12 @@ export function twoStroke<T extends Env>(title: string, release: string) {
                 "application/x-www-form-urlencoded"
                   ? Object.fromEntries(new URLSearchParams(await req.text()))
                   : await req.json();
-              const body = route.input.safeParse(rawBody);
+              const input =
+                route.input instanceof Function
+                  ? await route.input({ req, env })
+                  : route.input;
+
+              const body = input.safeParse(rawBody);
               if (body.success)
                 response = await route.handler({
                   req,
@@ -338,7 +343,7 @@ export function twoStroke<T extends Env>(title: string, release: string) {
     >(
       auth: Route<T, A>["auth"],
       path: P,
-      input: I,
+      input: I | ((c: { req: Request; env: T }) => Promise<I>),
       output: O,
       handler: Handler<T, I, O, A, P>,
       params?: PP,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export type Route<T extends Env, A> =
       method: "POST" | "PUT";
       path: string;
       matcher: RegExp;
-      input: ZodSchema;
+      input: ZodSchema | ((c: { req: Request; env: T }) => Promise<ZodSchema>);
       output: ZodSchema;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       handler: Handler<T, any, any, A, string>;


### PR DESCRIPTION
The specific use case here is wanting to have a dynamic schema requiring a number of answers - the number of tags in the recipe, in self-driving. The function will return that dynamic schema. This will mean we can return a 400 in a standardised way when the wrong number of answers is provided as if it was any other kind of schema error, rather than doing it at a different point in the call to other schema validation.
