### PR TITLE
allow custom headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,9 +272,9 @@ export function twoStroke<T extends Env>(title: string, release: string) {
     },
     noAuth,
     pbkdf:
-      (k: keyof T) =>
+      (k: keyof T, customHeaderName: string = "Authorization") =>
       async ({ req, env }: { req: Request; env: T }) => {
-        const [scheme, token] = (req.headers.get("Authorization") ?? " ").split(
+        const [scheme, token] = (req.headers.get(customHeaderName) ?? " ").split(
           " ",
         );
         if (


### PR DESCRIPTION
Sometimes the token is on a different header name e.g. `X-Amz-Firehose-Access-Key` 

Defaults to current `Authorization` if not configured.