### PR TITLE
Use Jose not jwk-subtle and support non-oidc providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
     "eslint-config-two-stroke": "^1.5.7",
     "eslint-config-typescript": "^3.0.0",
     "jose": "^6.2.3",
-    "jwk-subtle": "^1.1.8",
     "mime": "^4.1.0",
     "miniflare": "^4.20260701.0",
     "msw": "^2.14.6",
     "openapi-fetch": "^0.17.0",
     "openapi-typescript": "^7.13.0",
-    "pbkdf-subtle": "^1.1.8",
     "toucan-js": "^4.1.1",
     "zod": "^4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
-      jwk-subtle:
-        specifier: ^1.1.8
-        version: 1.1.8
       mime:
         specifier: ^4.1.0
         version: 4.1.0
@@ -56,9 +53,6 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@6.0.3)
-      pbkdf-subtle:
-        specifier: ^1.1.8
-        version: 1.1.8
       toucan-js:
         specifier: ^4.1.1
         version: 4.1.1
@@ -1566,10 +1560,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jwk-subtle@1.1.8:
-    resolution: {integrity: sha512-Jfom7tuaFz3VC5b3LfuzG+G4aGA5BHPrPAsO/n6I1BjiYSCDDxtPXZbAiFM8ocTobHRFqj1rLW6YriV5sSvbYA==}
-    engines: {node: ^24.9.0}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1758,11 +1748,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pbkdf-subtle@1.1.8:
-    resolution: {integrity: sha512-pSZ9zNwOIuS2z1M9l6ri0TLPsj9XJP+tqr0clAvKQEQp095l9BBCVr4Uu/1PKq097Bjnw3eiCrHOeJpSyVyjKw==}
-    engines: {node: ^24.9.0}
-    hasBin: true
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3437,8 +3422,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jwk-subtle@1.1.8: {}
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3624,8 +3607,6 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
-
-  pbkdf-subtle@1.1.8: {}
 
   picocolors@1.1.1: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { verify as jwkVerify } from "jwk-subtle";
-import { verify as pbkdfVerify } from "pbkdf-subtle";
 import { Toucan } from "toucan-js";
 import { type ZodSafeParseResult, z, ZodObject, ZodType } from "zod/v4";
 import { openAPI } from "./open-api";
 import { type Handler, type Route } from "./types";
+import type { JSONWebKeySet } from "jose";
+import { pbkdfVerify, jwkVerifyMulti } from "./util";
 
 // eslint-disable-next-line @typescript-eslint/require-await
 const noAuth = async () => null;
@@ -301,7 +301,7 @@ export function twoStroke<T>(
     },
     noAuth,
     pbkdf:
-      (k: keyof T, customHeaderName: string = "Authorization") =>
+      (k: keyof T, customHeaderName = "Authorization") =>
       async ({ req, env }: { req: Request; env: T }) => {
         const [scheme, token] = (req.headers.get(customHeaderName) ?? " ").split(" ");
         if (
@@ -309,20 +309,28 @@ export function twoStroke<T>(
           (await pbkdfVerify(env[k] as string, token ?? ""))
         )
           return;
-        throw Error("Invalid");
+        throw new Error("Invalid");
       },
     jwt:
       <J>(k: keyof T, ak: keyof T) =>
       async ({ req, env }: { req: Request; env: T }) => {
         const [scheme, token] = (req.headers.get("Authorization") ?? " ").split(" ");
         if (scheme === "Bearer") {
-          const claims = await jwkVerify<J>(token ?? "", env[k] as string, env[ak] as string);
+          const rawIssuer = env[k] as string;
+          const rawAudience = env[ak] as string;
+          const issuer = rawIssuer.startsWith("{")
+            ? (JSON.parse(rawIssuer) as Record<string, JSONWebKeySet | true>)
+            : { [rawIssuer]: true as const };
+          const audience = rawAudience.startsWith("[")
+            ? (JSON.parse(rawAudience) as string[])
+            : [rawAudience];
+          const claims = await jwkVerifyMulti<J>(token ?? "", issuer, audience);
           if (!claims) {
-            throw Error("Invalid");
+            throw new Error("Invalid");
           }
           return claims;
         }
-        throw Error("Invalid");
+        throw new Error("Invalid");
       },
     queueHandler<I extends ZodType>(
       input: I,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,77 @@
+import {
+  type FlattenedJWSInput,
+  type JSONWebKeySet,
+  type JWSHeaderParameters,
+  createLocalJWKSet,
+  createRemoteJWKSet,
+  decodeJwt,
+  jwtVerify,
+} from "jose";
+
+export async function pbkdfVerify(key: string, password: string) {
+  return (
+    [
+      ...new Uint8Array(
+        await crypto.subtle.deriveBits(
+          {
+            name: "PBKDF2",
+            hash: "SHA-256",
+            salt: new Uint8Array([...atob(key).slice(3, 19)].map((ch) => ch.charCodeAt(0))),
+            iterations: parseInt(
+              [...atob(key).slice(19, 22)].map((ch) => ch.charCodeAt(0).toString(16)).join(""),
+              16,
+            ),
+          },
+          await crypto.subtle.importKey(
+            "raw",
+            new TextEncoder().encode(password),
+            "PBKDF2",
+            false,
+            ["deriveBits"],
+          ),
+          256,
+        ),
+      ),
+    ]
+      .map((byte) => String.fromCharCode(byte))
+      .join("") === atob(key).slice(22, 54)
+  );
+}
+
+export async function jwkVerifyMulti<J>(
+  token: string,
+  issuers: Record<string, JSONWebKeySet | true>,
+  audiences: string[],
+) {
+  const unverifiedClaims = decodeJwt(token);
+  if (!unverifiedClaims.iss) throw new Error("Invalid");
+  const issuer = issuers[unverifiedClaims.iss];
+  if (!issuer) throw new Error("Invalid");
+
+  let JWKS: (
+    protectedHeader?: JWSHeaderParameters,
+    token?: FlattenedJWSInput,
+  ) => Promise<CryptoKey>;
+
+  if (issuer === true) {
+    // OIDC
+    const oidcRequest = await fetch(
+      `${unverifiedClaims.iss}${unverifiedClaims.iss.endsWith("/") ? "" : "/"}.well-known/openid-configuration`,
+    );
+    const oidc = await oidcRequest.json<{ jwks_uri: string }>();
+    JWKS = createRemoteJWKSet(new URL(oidc.jwks_uri));
+  } else {
+    JWKS = createLocalJWKSet(issuer);
+  }
+
+  const claims = (
+    await jwtVerify<J>(token ?? "", JWKS, {
+      algorithms: ["RS256", "ES256"],
+      audience: audiences,
+    })
+  ).payload;
+  if (!claims) {
+    throw new Error("Invalid");
+  }
+  return claims;
+}


### PR DESCRIPTION
Provide a clean upgrade path so all existing issuer/audience environment variables work; but future ones can optionally include multiple issuers and/or audiences and can supply keys rather then needing the OIDC.